### PR TITLE
Django 2 compatibility

### DIFF
--- a/djcelery_model/migrations/0001_initial.py
+++ b/djcelery_model/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('object_id', models.PositiveIntegerField()),
                 ('task_id', models.CharField(unique=True, max_length=255)),
                 ('state', models.PositiveIntegerField(default=0, choices=[(0, b'PENDING'), (1, b'STARTED'), (2, b'RETRY'), (3, b'FAILURE'), (4, b'SUCCESS')])),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/djcelery_model/models.py
+++ b/djcelery_model/models.py
@@ -76,7 +76,7 @@ class ModelTaskMeta(models.Model):
         (ModelTaskMetaState.SUCCESS, 'SUCCESS'),
     )
 
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()
     task_id = models.CharField(max_length=255, unique=True)


### PR DESCRIPTION
Due to `on_delete` being mandatory from Django 2 onwards, this app is currently incompatible with Django 2.

The commited fix has been working fine with my Django 2.2.5, Celery 4.2 project so far.
I simply added the implicit default value for `on_delete` as an explicit argument, so the behaviour shouldn't change at all compared to Django 1.11.